### PR TITLE
docs: Translate documentation of shopping craigslist from Chinese to English.

### DIFF
--- a/docs/en/shopping.md
+++ b/docs/en/shopping.md
@@ -42,6 +42,20 @@ Parameter `time` only works when `mostwanted` is chosen as the category.
 
 <RouteEn author="KTachibanaM" example="/booth.pm/shop/annn-boc0123" path="/booth.pm/shop/:subdomain" :paramsDesc="['Shop subdomain']" />
 
+## Craigslist
+
+### Shop
+
+<Route author="lxiange" example="/craigslist/sfbay/sso?query=folding+bike&sort=rel" path="/craigslist/:location/:type?" :paramsDesc="['位置，即Craigslist的子域，如sfbay', '搜索类型，如sso']"/>
+
+> We use RSSHub to implement the searching of Craigslist
+> An example of a full original search url:
+> <https://sfbay.craigslist.org/search/sso?query=folding+bike&sort=rel>
+>
+> the `xxx` in `/search/xxx` is the search type, just refer to the original search url.
+> The query string is the actual name of query, in this case is folding bike
+
+
 ## Guiltfree.pl
 
 ### Onsale


### PR DESCRIPTION
From docs/shopping.md to docs/en/shopping.md

# The Original Chinese docs:

## Craigslist

### 商品搜索

<Route author="lxiange" example="/craigslist/sfbay/sso?query=folding+bike&sort=rel" path="/craigslist/:location/:type?" :paramsDesc="['位置，即Craigslist的子域，如sfbay', '搜索类型，如sso']"/>

> 由于 Craigslist 取消了 RSS 订阅搜索功能，因此用 RSSHub 来实现了类似效果。
> 一个完整原始搜索会像这样：
> <https://sfbay.craigslist.org/search/sso?query=folding+bike&sort=rel>
>
> /search/xxx 后跟的 "xxx" 为搜索类型，直接参考原始请求即可。
> query string 是实际的搜索内容。

# The Translated English docs:

## Craigslist

### Shop

<Route author="lxiange" example="/craigslist/sfbay/sso?query=folding+bike&sort=rel" path="/craigslist/:location/:type?" :paramsDesc="['位置，即Craigslist的子域，如sfbay', '搜索类型，如sso']"/>

> We use RSSHub to implement the searching of Craigslist
> An example of a full original search url:
> <https://sfbay.craigslist.org/search/sso?query=folding+bike&sort=rel>
>
> the `xxx` in `/search/xxx` is the search type, just refer to the original search url.
> The query string is the actual name of query, in this case is folding bike

